### PR TITLE
Some fix

### DIFF
--- a/src/eq.ml
+++ b/src/eq.ml
@@ -99,6 +99,7 @@ module Witness : sig
   type 'a t
   val v : unit -> 'a t
   val eq: 'a t -> 'b t -> ('a, 'b) refl option
+  val cmp: 'a t -> 'b t -> int
 end = struct
 
   type _ equality = ..
@@ -124,6 +125,13 @@ end = struct
       | B.Eq -> Some Refl
       | _    -> None
 
+  let cmp: type a b. a t -> b t -> int =
+    fun ((module A) as a) ((module B) as b) -> match eq a b with
+      | Some Refl -> 0
+      | None ->
+        let ext_a = Obj.extension_id (Obj.extension_constructor A.Eq) in
+        let ext_b = Obj.extension_id (Obj.extension_constructor B.Eq) in
+        ext_a - ext_b
 end
 
 type 'a witness = { name: string; wit : 'a Witness.t }

--- a/src/jbuild
+++ b/src/jbuild
@@ -2,7 +2,7 @@
  ((name        lambda)
   (public_name lambda)
   (libraries   (fmt logs lwt higher))
-  (preprocess  (pps (ppx_deriving.show ppx_deriving.eq)))))
+  (preprocess  (pps (ppx_deriving.show ppx_deriving.eq ppx_deriving.ord)))))
 
 (ocamllex (lexer))
 

--- a/src/parsetree.ml
+++ b/src/parsetree.ml
@@ -50,7 +50,7 @@ module Type = struct
     | Either of t * t
     | Result of t * t
     | Abstract of abstract
-  [@@deriving show, eq]
+  [@@deriving show, eq, ord]
 
   let _ = show
   let dump = pp
@@ -100,25 +100,34 @@ end
 type typ = Type.t
 let pp_typ = Type.pp
 let equal_typ = Type.equal
+let compare_typ = Type.compare
 
-type value = V: { v: 'a; t: 'a T.t; pp: 'a Fmt.t } -> value
+type 'a cmp = 'a -> 'a -> int
+type value = V: { v: 'a; t: 'a T.t; pp: 'a Fmt.t; cmp: 'a cmp; } -> value
 
 let pp_value ppf (V t) = t.pp ppf t.v
 
 let equal_value (V a) (V b) =
   match T.equal a.t b.t with
-  | Some Eq.Refl -> a.v = b.v
+  | Some Eq.Refl -> a.cmp a.v b.v = 0
   | None         -> false
+
+let compare_value (V a) (V b) =
+  match T.equal a.t b.t with
+  | Some Eq.Refl -> a.cmp a.v b.v
+  | None         -> 1
 
 type primitive =
   { name : string
   ; args : typ list
   ; ret  : typ
-  ; exp  : value list -> value [@equal fun _ _ -> true] }
-[@@deriving show, eq]
+  ; exp  : value list -> value
+        [@equal   fun _ _ -> true]
+        [@compare fun _ _ -> 0] }
+[@@deriving show, eq, ord]
 
 type arithmetic = [ `Add | `Sub | `Mul | `Div ]
-[@@deriving show, eq]
+[@@deriving show, eq, ord]
 
 type binop = [ arithmetic | `Pair | `Eq ]
 and unop = Fst | Snd | L of typ | R of typ | Ok of typ | Error of typ
@@ -140,14 +149,15 @@ and expr =
            ; b : expr
            ; s : expr }
   | If  of expr * expr * expr
-[@@deriving show, eq]
+[@@deriving show, eq, ord]
 
 let _ =
   show_expr, show_primitive, show_arithmetic, show_binop, show_unop,
-  show_var
+  show_var, compare_binop, compare_unop, compare_var
 
 let dump = pp_expr
 let equal = equal_expr
+let compare = compare_expr
 
 let dump_var ppf v = Fmt.pf ppf "$%d" v.id
 
@@ -224,14 +234,14 @@ let pp ppf t =
   in
   aux [] ppf t
 
-let value v t pp = Val (V {v; t; pp})
+let value v t pp cmp = Val (V {v; t; pp; cmp;})
 let prim p = Prm p
 
-let unit = value () Unit (fun ppf () -> Fmt.pf ppf "()")
-let int n = value n Int Fmt.int
-let int32 n = value n Int32 Fmt.int32
-let int64 n = value n Int64 Fmt.int64
-let string s = value s String (fun ppf s -> Fmt.pf ppf "%S" s)
+let unit = value () Unit (fun ppf () -> Fmt.pf ppf "()") (fun () () -> 0)
+let int n = value n Int Fmt.int (-)
+let int32 n = value n Int32 Fmt.int32 Int32.compare
+let int64 n = value n Int64 Fmt.int64 Int64.compare
+let string s = value s String (fun ppf s -> Fmt.pf ppf "%S" s) String.compare
 
 let list ?typ l = Lst (typ, l)
 let array ?typ l = Arr (typ, l)
@@ -244,7 +254,11 @@ let pair a b = Bin (`Pair, a, b)
 let apply f a = App (f, a)
 let var id = Var { id }
 let match_ s a b = Swt {a; b; s}
-let bool b = value b Bool Fmt.bool
+let bool b = value b Bool Fmt.bool (fun a b -> match a, b with
+    | true, true
+    | false, false -> 0
+    | true, false -> 1
+    | false, true -> (-1))
 let true_ = bool true
 let false_ = bool false
 

--- a/src/parsetree.ml
+++ b/src/parsetree.ml
@@ -29,6 +29,10 @@ module Type = struct
     | Some Eq.Refl -> true
     | _ -> false
 
+  let compare_abstract (A a) (A b) =
+    let c = String.compare a.name b.name in
+    if c = 0 then Eq.Witness.cmp a.wit b.wit else c
+
   type t =
     | Unit
     | Int

--- a/src/parsetree.ml
+++ b/src/parsetree.ml
@@ -235,6 +235,7 @@ let pp ppf t =
   aux [] ppf t
 
 let value v t pp cmp = Val (V {v; t; pp; cmp;})
+let of_value v = Val v
 let prim p = Prm p
 
 let unit = value () Unit (fun ppf () -> Fmt.pf ppf "()") (fun () () -> 0)

--- a/src/parsetree.mli
+++ b/src/parsetree.mli
@@ -176,6 +176,7 @@ val true_: expr
 val false_: expr
 
 val value: 'a -> 'a T.t -> 'a Fmt.t -> 'a cmp -> expr
+val of_value: value -> expr
 
 val lambda: (string * typ) list -> expr -> expr
 

--- a/src/parsetree.mli
+++ b/src/parsetree.mli
@@ -86,10 +86,10 @@ module Type: sig
   val dump: t Fmt.t
 end
 
-type 'a cmp = 'a -> 'a -> int
+type 'a eq = 'a -> 'a -> bool
 
 (** OCaml value (with type and pretty-printer). *)
-type value = V: { v: 'a; t: 'a T.t; pp: 'a Fmt.t; cmp: 'a cmp; } -> value
+type value = V: { v: 'a; t: 'a T.t; pp: 'a Fmt.t; eq: 'a eq; } -> value
 
 (** Type of {!expr}. *)
 type typ = Type.t
@@ -148,7 +148,7 @@ and unop =  Fst | Snd | L of typ | R of typ | Ok of typ | Error of typ
 (** {2 Pretty-printers.} *)
 
 val pp: expr Fmt.t
-val compare: expr cmp
+val equal: expr eq
 val dump: expr Fmt.t
 
 val pp_value: value Fmt.t
@@ -175,7 +175,7 @@ val string: string -> expr
 val true_: expr
 val false_: expr
 
-val value: 'a -> 'a T.t -> 'a Fmt.t -> 'a cmp -> expr
+val value: 'a -> 'a T.t -> 'a Fmt.t -> 'a eq -> expr
 val of_value: value -> expr
 
 val lambda: (string * typ) list -> expr -> expr
@@ -207,5 +207,3 @@ val ( + ): expr -> expr -> expr
 val ( - ): expr -> expr -> expr
 val ( * ): expr -> expr -> expr
 val ( / ): expr -> expr -> expr
-
-val equal: expr -> expr -> bool

--- a/src/parsetree.mli
+++ b/src/parsetree.mli
@@ -86,8 +86,10 @@ module Type: sig
   val dump: t Fmt.t
 end
 
+type 'a cmp = 'a -> 'a -> int
+
 (** OCaml value (with type and pretty-printer). *)
-type value = V: { v: 'a; t: 'a T.t; pp: 'a Fmt.t } -> value
+type value = V: { v: 'a; t: 'a T.t; pp: 'a Fmt.t; cmp: 'a cmp; } -> value
 
 (** Type of {!expr}. *)
 type typ = Type.t
@@ -146,6 +148,7 @@ and unop =  Fst | Snd | L of typ | R of typ | Ok of typ | Error of typ
 (** {2 Pretty-printers.} *)
 
 val pp: expr Fmt.t
+val compare: expr cmp
 val dump: expr Fmt.t
 
 val pp_value: value Fmt.t
@@ -172,7 +175,7 @@ val string: string -> expr
 val true_: expr
 val false_: expr
 
-val value: 'a -> 'a T.t -> 'a Fmt.t -> expr
+val value: 'a -> 'a T.t -> 'a Fmt.t -> 'a cmp -> expr
 
 val lambda: (string * typ) list -> expr -> expr
 

--- a/src/typedtree.ml
+++ b/src/typedtree.ml
@@ -594,7 +594,11 @@ module Expr = struct
       let p = fst_ re.p, Type.untype (snd_ re.p) in
       let b = untype re.body in
       P.fix p r b
-    | Swt _ -> failwith "TODO"
+    | Swt { s; a; b; } ->
+      let s = untype s in
+      let a = untype a in
+      let b = untype b in
+      P.match_ s a b
 
   type v = V: (unit, 'a) t * 'a Type.t -> v
 

--- a/src/typedtree.ml
+++ b/src/typedtree.ml
@@ -558,7 +558,9 @@ module Expr = struct
   let rec untype: type a e. (e, a) t -> Parsetree.expr = fun e ->
     let module P = Parsetree in
     match e with
-    | Val {v;t;pp}     -> P.value v t pp
+    | Val {t=Type.List t;v=[];_} -> P.list ~typ:(Type.untype t) []
+    | Val {t=Type.Array t;v=[||];_} -> P.array ~typ:(Type.untype t) [||]
+    | Val {v;t;pp;cmp} -> P.value v t pp cmp
     | Prm x            -> P.prim (Prim.untype x)
     | Uno (Fst, x)     -> P.fst (untype x)
     | Uno (Snd, x)     -> P.snd (untype x)

--- a/src/typedtree.ml
+++ b/src/typedtree.ml
@@ -736,7 +736,7 @@ module Expr = struct
            let Type.V t = Type.typ t in
            match Type.equal t tr' with
            | Some Eq.Refl -> ()
-           | _ -> failwith "wrong constraint for option type");
+           | _ -> error e g [ TypMismatch {a=Type.V t; b=Type.V tr'} ]);
         (match Env.eq g' g'' with
          | Some Eq.Refl -> Expr (Opt (tr', Some x'), g', Option tr')
          | _ -> error e g [ EnvMismatch { g = Env.V g'; g' = Env.V g'' } ])
@@ -834,7 +834,8 @@ module Expr = struct
         let Expr (b', g'', tb') = aux b g in
         (match Type.equal ta' tb', Env.eq g' g'' with
          | Some Eq.Refl, Some Eq.Refl -> Expr (Bin (Eq, a', b'), g', Bool)
-         | _, _ -> assert false)
+         | _, _ -> error e g [ TypMismatch {a=Type.V ta'; b=Type.V tb'}
+                             ; EnvMismatch {g=Env.V g'; g'=Env.V g''} ])
       | Swt { a; b; s; } ->
         (match aux s g with
          | Expr (s', g'', Type.Either (l', r')) ->

--- a/src/typedtree.mli
+++ b/src/typedtree.mli
@@ -63,7 +63,7 @@ module Type: sig
   (** {2 Pretty-printer.} *)
 
   val pp_val: 'a t -> 'a Fmt.t
-  val cmp_val: 'a t -> 'a Parsetree.cmp
+  val eq_val: 'a t -> 'a Parsetree.eq
 
   (** {2 Witness type value.} *)
 
@@ -72,7 +72,7 @@ module Type: sig
   val typ: Parsetree.typ -> v
   (** [typ ut] returns a witness of type [ut]. *)
 
-  val cmp: 'a t Parsetree.cmp
+  val eq: 'a t Parsetree.eq
   val pp: 'a t Fmt.t
 end
 

--- a/src/typedtree.mli
+++ b/src/typedtree.mli
@@ -173,6 +173,9 @@ module Expr: sig
   val typ: Parsetree.expr -> (v, error) result
   (** [typ unsafe_expr] tries to type [unsafe_expr] and returns an {!expr}. *)
 
+  val pp: ('e, 'a) t Fmt.t
+  (** Pretty-printer of {!t}. *)
+
 end
 
 type 'a typ = 'a Type.t

--- a/src/typedtree.mli
+++ b/src/typedtree.mli
@@ -63,6 +63,7 @@ module Type: sig
   (** {2 Pretty-printer.} *)
 
   val pp_val: 'a t -> 'a Fmt.t
+  val cmp_val: 'a t -> 'a Parsetree.cmp
 
   (** {2 Witness type value.} *)
 
@@ -70,6 +71,9 @@ module Type: sig
 
   val typ: Parsetree.typ -> v
   (** [typ ut] returns a witness of type [ut]. *)
+
+  val cmp: 'a t Parsetree.cmp
+  val pp: 'a t Fmt.t
 end
 
 module Value: sig


### PR DESCRIPTION
* We add a `compare` function as pretty-printer function for any value in `Parsetree` and `Typedtree` module - and be able to properly compare value instead to use `Pervasives.compare`.
* We add a pretty-printer on `Typedtree.Expr.t`
* To let the user to write this kind of code: `[ my_var; ... ]` or `[| my_var |]`, we add 2 constructors in the internal GADT. `Cons` for a list (as a binary operator) and `Nar` and `Arr` for a n-ary constructor (`Nar`) which can be used to create an array `Arr`
* We fixed a TODO and un-type a `Switch`
* Most important we avoid any exception leak and add a new error: `UnboundVariable` specially to know when a fuzzer produce a bad code

Then, this is a base for the fuzzer next (soon).