### PR TITLE
Exception leaks

### DIFF
--- a/proto/lambda_protobuf.ml
+++ b/proto/lambda_protobuf.ml
@@ -463,6 +463,9 @@ let of_request
     of_expr ~gamma ?primitives request.Types.expr,
     to_typ ~gamma request.Types.typ, request.Types.output
 
+let output_of_request : Types.request -> int64 =
+  fun request -> request.Types.output
+
 let to_request
   : expr * Type.t * int64 -> (Types.request, [`Msg of string]) result
   = fun (expr, typ, output) ->

--- a/proto/lambda_protobuf.mli
+++ b/proto/lambda_protobuf.mli
@@ -15,6 +15,8 @@ val of_request:
   ?primitives:primitive Primitives.t ->
   Lambda_types.request -> expr * Type.t * int64
 
+val output_of_request: Lambda_types.request -> int64
+
 val of_reply:
   ?gamma:Type.abstract Gamma.t -> Lambda_types.reply ->
   (value, [ `Msg of string ]) result


### PR DESCRIPTION
Be able to catch exception from `of_request` function (which extract a binded request with local environment from a protobuf request) and reply an error to the client.